### PR TITLE
feat: Implement UI for Citation-Augmented Analysis

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,7 @@
+node_modules
+dist
+.DS_Store
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+jules-scratch/

--- a/src/components/ColorCodedText.tsx
+++ b/src/components/ColorCodedText.tsx
@@ -1,0 +1,43 @@
+import React from 'react';
+import { Segment } from '../types/factCheck';
+
+interface ColorCodedTextProps {
+    segments: Segment[] | undefined;
+}
+
+const ColorCodedText: React.FC<ColorCodedTextProps> = ({ segments }) => {
+    if (!segments || segments.length === 0) {
+        return (
+            <div className="bg-slate-800/50 p-6 rounded-2xl text-center">
+                <p className="text-slate-300">No text analysis is available for this report.</p>
+            </div>
+        );
+    }
+
+    const getColorClass = (color: Segment['color']) => {
+        switch (color) {
+            case 'green':
+                return 'bg-green-500/20 text-green-300';
+            case 'yellow':
+                return 'bg-yellow-500/20 text-yellow-300';
+            case 'red':
+                return 'bg-red-500/20 text-red-300';
+            default:
+                return 'text-slate-300';
+        }
+    };
+
+    return (
+        <div className="bg-slate-800/50 p-6 rounded-2xl">
+            <p className="text-slate-200 leading-relaxed">
+                {segments.map((segment, index) => (
+                    <span key={index} className={`px-1 py-0.5 rounded-md transition-colors ${getColorClass(segment.color)}`}>
+                        {segment.text}
+                    </span>
+                ))}
+            </p>
+        </div>
+    );
+};
+
+export default ColorCodedText;

--- a/src/components/EvidenceTable.tsx
+++ b/src/components/EvidenceTable.tsx
@@ -75,6 +75,7 @@ const EvidenceTable: React.FC<{ evidence: EvidenceItem[] }> = ({ evidence }) => 
         const lowercasedFilter = filter.toLowerCase();
         
         return [...evidence]
+            .filter(item => item.publisher !== 'Internal Knowledge Base')
             .filter(item => 
                 item.quote.toLowerCase().includes(lowercasedFilter) ||
                 item.publisher.toLowerCase().includes(lowercasedFilter)

--- a/src/components/ReportView.tsx
+++ b/src/components/ReportView.tsx
@@ -5,10 +5,11 @@ import ScoreBreakdown from './ScoreBreakdown';
 import EvidenceTable from './EvidenceTable';
 import MethodologyView from './MethodologyView';
 import SearchResults from './SearchResults';
+import ColorCodedText from './ColorCodedText';
 
 interface ReportViewProps {
     report: FactCheckReport;
-    activeTab: 'Evidence' | 'Breakdown' | 'Methodology' | 'Search Results';
+    activeTab: 'Evidence' | 'Breakdown' | 'Methodology' | 'Search Results' | 'Original Text Analysis';
 }
 
 const ReportView: React.FC<ReportViewProps> = ({ report, activeTab }) => {
@@ -16,11 +17,13 @@ const ReportView: React.FC<ReportViewProps> = ({ report, activeTab }) => {
         case 'Evidence':
             return <EvidenceTable evidence={report.evidence} />;
         case 'Breakdown':
-            return <ScoreBreakdown breakdown={report.score_breakdown} />;
+            return <ScoreBreakdown breakdown={report.score_breakdown} reasoning={report.reasoning} />;
         case 'Methodology':
             return <MethodologyView metadata={report.metadata} />;
         case 'Search Results':
             return <SearchResults searchEvidence={report.searchEvidence} />;
+        case 'Original Text Analysis':
+            return <ColorCodedText segments={report.originalTextSegments} />;
         default:
             return null;
     }

--- a/src/components/ScoreBreakdown.tsx
+++ b/src/components/ScoreBreakdown.tsx
@@ -29,7 +29,7 @@ const MetricBar: React.FC<{ metric: ScoreMetric }> = ({ metric }) => {
 };
 
 
-const ScoreBreakdown: React.FC<{ breakdown: ScoreBreakdownType }> = ({ breakdown }) => {
+const ScoreBreakdown: React.FC<{ breakdown: ScoreBreakdownType, reasoning?: string }> = ({ breakdown, reasoning }) => {
     return (
         <div className="bg-slate-800/50 p-6 rounded-2xl space-y-6">
             <div>
@@ -43,6 +43,12 @@ const ScoreBreakdown: React.FC<{ breakdown: ScoreBreakdownType }> = ({ breakdown
                     <MetricBar key={metric.name} metric={metric} />
                 ))}
             </div>
+            {reasoning && (
+                <div className="border-t border-slate-700/50 pt-4">
+                    <h4 className="text-md font-semibold text-slate-200 mb-2">AI Reasoning</h4>
+                    <p className="text-sm text-slate-300 whitespace-pre-wrap">{reasoning}</p>
+                </div>
+            )}
             {breakdown.confidence_intervals && (
                 <div className="text-center text-sm text-slate-300 border-t border-slate-700/50 pt-4">
                     Confidence Interval: 


### PR DESCRIPTION
This commit introduces the UI changes to support the 'Citation-Augmented Core Analysis' method.

- Creates a new `ColorCodedText.tsx` component to display the color-coded text segments.
- Updates `ReportView.tsx` to include a new 'Original Text Analysis' tab that uses the `ColorCodedText` component.
- Modifies `EvidenceTable.tsx` to filter out evidence from the 'Internal Knowledge Base'.
- Updates `ScoreBreakdown.tsx` to display the AI's reasoning for its verdict.
- Adds a `.gitignore` file to ignore `node_modules` and other generated files.