### PR TITLE
Fixes a build error where the ColorCodedText module could not be found.

### DIFF
--- a/src/components/ReportView.tsx
+++ b/src/components/ReportView.tsx
@@ -5,7 +5,7 @@ import ScoreBreakdown from './ScoreBreakdown';
 import EvidenceTable from './EvidenceTable';
 import MethodologyView from './MethodologyView';
 import SearchResults from './SearchResults';
-import ColorCodedText from './ColorCodedText';
+import ColorCodedText from './ColorCodedText.tsx';
 
 interface ReportViewProps {
     report: FactCheckReport;


### PR DESCRIPTION
The TypeScript module resolution was failing because the '.tsx' extension was missing from the import statement in ReportView.tsx. Adding the extension resolves the issue.