### PR TITLE
feat: Add guardrails to prevent frontend crash and configure Tailwind

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,9 +15,9 @@
       "devDependencies": {
         "@types/node": "^22.14.0",
         "@vitejs/plugin-react": "^5.0.0",
-        "autoprefixer": "^10.4.16",
-        "postcss": "^8.4.32",
-        "tailwindcss": "^3.4.0",
+        "autoprefixer": "^10.4.21",
+        "postcss": "^8.5.6",
+        "tailwindcss": "^3.4.17",
         "typescript": "~5.8.2",
         "vite": "^6.2.0"
       }

--- a/package.json
+++ b/package.json
@@ -10,17 +10,17 @@
     "vercel-build": "npm run build"
   },
   "dependencies": {
-    "react": "^19.1.1",
     "@google/genai": "^1.19.0",
+    "react": "^19.1.1",
     "react-dom": "^19.1.1"
   },
   "devDependencies": {
     "@types/node": "^22.14.0",
     "@vitejs/plugin-react": "^5.0.0",
+    "autoprefixer": "^10.4.21",
+    "postcss": "^8.5.6",
+    "tailwindcss": "^3.4.17",
     "typescript": "~5.8.2",
-    "vite": "^6.2.0",
-    "tailwindcss": "^3.4.0",
-    "autoprefixer": "^10.4.16",
-    "postcss": "^8.4.32"
+    "vite": "^6.2.0"
   }
 }

--- a/postcss.config.js
+++ b/postcss.config.js
@@ -1,0 +1,6 @@
+export default {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+  },
+}

--- a/src/components/Dashboard.tsx
+++ b/src/components/Dashboard.tsx
@@ -4,6 +4,7 @@ import { FactCheckReport } from '../types/factCheck';
 import ReportView from './ReportView';
 import { CheckCircleIcon, ExclamationCircleIcon, XCircleIcon, PencilSquareIcon } from './icons';
 import AutoEditor from './AutoEditor';
+import DashboardSkeleton from './DashboardSkeleton';
 
 // A new, self-contained component to visually represent the final verdict.
 interface VerdictDisplayProps {
@@ -51,7 +52,8 @@ const VerdictDisplay: React.FC<VerdictDisplayProps> = ({ verdict, score }) => {
 };
 
 interface DashboardProps {
-    result: FactCheckReport;
+    result: FactCheckReport | null;
+    isLoading: boolean;
 }
 
 type Tab = 'Overview' | 'Evidence' | 'Breakdown' | 'Methodology' | 'Search Results' | 'Original Text Analysis';
@@ -99,9 +101,26 @@ const ScoreCircle: React.FC<{ score: number }> = ({ score }) => {
     );
 };
 
-const Dashboard: React.FC<DashboardProps> = ({ result }) => {
+const Dashboard: React.FC<DashboardProps> = ({ result, isLoading }) => {
     const [activeTab, setActiveTab] = useState<Tab>('Overview');
     const [isEditorOpen, setIsEditorOpen] = useState(false);
+
+    if (isLoading) {
+        return <DashboardSkeleton />;
+    }
+
+    if (!result) {
+        return null;
+    }
+
+    // Add a final sanity check for essential data before rendering
+    if (!result.final_verdict || !result.score_breakdown || !result.evidence) {
+        return (
+            <div className="text-center py-10 text-slate-400">
+                <p>Error: Incomplete analysis report received. Please try again.</p>
+            </div>
+        );
+    }
 
     // Show Original Text Analysis tab only if segments are available
     const availableTabs: Tab[] = ['Overview'];

--- a/src/components/DashboardSkeleton.tsx
+++ b/src/components/DashboardSkeleton.tsx
@@ -1,0 +1,43 @@
+import React from 'react';
+
+const DashboardSkeleton: React.FC = () => {
+  return (
+    <div className="space-y-8 animate-pulse">
+      {/* Header Skeleton */}
+      <div className="bg-slate-800/50 rounded-xl p-6 border border-slate-700">
+        <div className="grid grid-cols-1 md:grid-cols-3 gap-6">
+          <div className="md:col-span-1">
+            <div className="flex flex-col items-center space-y-4">
+              <div className="h-4 bg-slate-700 rounded w-2/3"></div>
+              <div className="h-10 bg-slate-700 rounded w-1/2"></div>
+              <div className="h-6 bg-slate-700 rounded w-1/3"></div>
+            </div>
+          </div>
+          <div className="md:col-span-2 space-y-3">
+            <div className="h-4 bg-slate-700 rounded w-1/4"></div>
+            <div className="h-4 bg-slate-700 rounded"></div>
+            <div className="h-4 bg-slate-700 rounded"></div>
+            <div className="h-4 bg-slate-700 rounded w-5/6"></div>
+          </div>
+        </div>
+      </div>
+
+      {/* Tab Navigation Skeleton */}
+      <div className="border-b border-slate-700">
+        <div className="flex space-x-8">
+          <div className="h-10 bg-slate-700 rounded w-24"></div>
+          <div className="h-10 bg-slate-700 rounded w-32"></div>
+          <div className="h-10 bg-slate-700 rounded w-40"></div>
+        </div>
+      </div>
+
+      {/* Tab Content Skeleton */}
+      <div className="space-y-4">
+        <div className="h-32 bg-slate-800/50 rounded-xl"></div>
+        <div className="h-64 bg-slate-800/50 rounded-xl"></div>
+      </div>
+    </div>
+  );
+};
+
+export default DashboardSkeleton;

--- a/src/components/EvidenceTable.tsx
+++ b/src/components/EvidenceTable.tsx
@@ -72,19 +72,29 @@ const EvidenceTable: React.FC<{ evidence: EvidenceItem[] }> = ({ evidence }) => 
     };
     
     const filteredAndSortedEvidence = useMemo(() => {
+        if (!Array.isArray(evidence)) {
+            return [];
+        }
+
         const lowercasedFilter = filter.toLowerCase();
-        
-        return [...evidence]
-            .filter(item => item.publisher !== 'Internal Knowledge Base')
-            .filter(item => 
-                item.quote.toLowerCase().includes(lowercasedFilter) ||
-                item.publisher.toLowerCase().includes(lowercasedFilter)
-            )
-            .sort((a, b) => {
-                if (a[sortKey] < b[sortKey]) return sortOrder === 'asc' ? -1 : 1;
-                if (a[sortKey] > b[sortKey]) return sortOrder === 'asc' ? 1 : -1;
-                return 0;
+
+        const filtered = evidence
+            .filter(item => item && item.publisher !== 'Internal Knowledge Base')
+            .filter(item => {
+                const quote = item.quote || '';
+                const publisher = item.publisher || '';
+                return quote.toLowerCase().includes(lowercasedFilter) ||
+                       publisher.toLowerCase().includes(lowercasedFilter);
             });
+
+        return filtered.sort((a, b) => {
+            const valA = a[sortKey] || '';
+            const valB = b[sortKey] || '';
+
+            if (valA < valB) return sortOrder === 'asc' ? -1 : 1;
+            if (valA > valB) return sortOrder === 'asc' ? 1 : -1;
+            return 0;
+        });
     }, [evidence, sortKey, sortOrder, filter]);
 
     if (evidence.length === 0) {

--- a/src/index.css
+++ b/src/index.css
@@ -1,0 +1,3 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -2,6 +2,7 @@
 import React from 'react';
 import ReactDOM from 'react-dom/client';
 import App from './App';
+import './index.css';
 
 const rootElement = document.getElementById('root');
 if (!rootElement) {

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,0 +1,8 @@
+/** @type {import('tailwindcss').Config} */
+export default {
+  content: ["./src/**/*.{js,ts,jsx,tsx}"],
+  theme: {
+    extend: {},
+  },
+  plugins: [],
+}


### PR DESCRIPTION
This commit addresses a crash in the frontend that occurred when the application tried to render a report with incomplete data. It also configures Tailwind CSS for production builds, resolving a console warning.

- In `Dashboard.tsx`:
  - Added a loading state with a skeleton component to improve user experience while data is being fetched.
  - Implemented checks to ensure the `result` object and its critical properties (`final_verdict`, `evidence`, etc.) are present before rendering dependent UI. This prevents crashes when the data is null or incomplete.

- In `EvidenceTable.tsx`:
  - Added defensive checks to the `useMemo` hook to ensure the `evidence` prop is an array before attempting to map over it.
  - Made filtering and sorting logic more robust by handling cases where properties on evidence items (like `quote` or `publisher`) might be null or undefined.

- Tailwind CSS Setup:
  - Installed `tailwindcss`, `postcss`, and `autoprefixer` as dev dependencies.
  - Created and configured `tailwind.config.js` and `postcss.config.js` for production builds.
  - Added the main `index.css` file with Tailwind's `@tailwind` directives.
  - Imported `index.css` into the application's entry point (`main.tsx`).