### PR TITLE
feat: Refactor blob storage to use server-side API

### DIFF
--- a/api/blob/delete-report.ts
+++ b/api/blob/delete-report.ts
@@ -1,0 +1,19 @@
+import { del } from '@vercel/blob';
+import { NextRequest, NextResponse } from 'next/server';
+
+export async function POST(request: NextRequest) {
+  try {
+    const { reportId } = await request.json();
+    const filename = `truescope-reports/${reportId}.json`;
+
+    await del(filename);
+
+    return NextResponse.json({ success: true });
+  } catch (error) {
+    console.error('Failed to delete report from blob storage:', error);
+    return NextResponse.json(
+      { error: 'Failed to delete report' },
+      { status: 500 }
+    );
+  }
+}

--- a/api/blob/save-fact-database.ts
+++ b/api/blob/save-fact-database.ts
@@ -1,0 +1,23 @@
+import { put } from '@vercel/blob';
+import { NextRequest, NextResponse } from 'next/server';
+
+export async function POST(request: NextRequest) {
+  try {
+    const facts = await request.json();
+    const dbPath = 'fact-database/db.json';
+
+    const blob = await put(dbPath, JSON.stringify(facts, null, 2), {
+      access: 'public',
+      contentType: 'application/json',
+      addRandomSuffix: false,
+    });
+
+    return NextResponse.json({ success: true, url: blob.url });
+  } catch (error) {
+    console.error('Failed to save fact database:', error);
+    return NextResponse.json(
+      { error: 'Failed to save fact database' },
+      { status: 500 }
+    );
+  }
+}

--- a/api/blob/save-report.ts
+++ b/api/blob/save-report.ts
@@ -1,0 +1,22 @@
+import { put } from '@vercel/blob';
+import { NextRequest, NextResponse } from 'next/server';
+
+export async function POST(request: NextRequest) {
+  try {
+    const report = await request.json();
+    const filename = `truescope-reports/${report.id}.json`;
+
+    const blob = await put(filename, JSON.stringify(report), {
+      access: 'public',
+      addRandomSuffix: false,
+    });
+
+    return NextResponse.json({ success: true, url: blob.url });
+  } catch (error) {
+    console.error('Failed to save report to blob storage:', error);
+    return NextResponse.json(
+      { error: 'Failed to save report' },
+      { status: 500 }
+    );
+  }
+}


### PR DESCRIPTION
- Moved Vercel Blob Storage write operations (`put`, `del`) from the client-side service to dedicated server-side API routes.
- Created new API endpoints:
  - `api/blob/save-fact-database.ts`
  - `api/blob/save-report.ts`
  - `api/blob/delete-report.ts`
- Updated `BlobStorageService` to make `fetch` calls to these new endpoints instead of interacting with the blob storage directly.
- This fixes the core security and authentication issue where the `BLOB_READ_WRITE_TOKEN` was required on the client side.