### PR TITLE
debug: Add console log to check for BLOB_READ_WRITE_TOKEN

### DIFF
--- a/api/blob/save-fact-database.ts
+++ b/api/blob/save-fact-database.ts
@@ -3,6 +3,12 @@ import { NextRequest, NextResponse } from 'next/server';
 
 export async function POST(request: NextRequest) {
   try {
+    // Debugging: Check if the environment variable is available
+    console.log(
+      'BLOB_READ_WRITE_TOKEN is set:',
+      !!process.env.BLOB_READ_WRITE_TOKEN
+    );
+
     const facts = await request.json();
     const dbPath = 'fact-database/db.json';
 


### PR DESCRIPTION
Adds a console log to the `save-fact-database` API route to verify if the `BLOB_READ_WRITE_TOKEN` environment variable is accessible at runtime. This is for debugging the 500 Internal Server Error.