### PR TITLE
Fix: Use deterministic hash for factCheckId

### DIFF
--- a/src/components/AutoEditor.tsx
+++ b/src/components/AutoEditor.tsx
@@ -264,7 +264,7 @@ const AutoEditor: React.FC<AutoEditorProps> = ({
           mode,
           result,
           originalText,
-          factCheckId: factCheckReport.metadata?.processing_time_ms || Date.now()
+          factCheckId: factCheckReport.id
         })
       });
 
@@ -286,7 +286,7 @@ const AutoEditor: React.FC<AutoEditorProps> = ({
           id: `batch_${Date.now()}`,
           results,
           originalText,
-          factCheckId: factCheckReport.metadata?.processing_time_ms || Date.now(),
+          factCheckId: factCheckReport.id,
           timestamp: new Date().toISOString()
         })
       });
@@ -307,7 +307,7 @@ const AutoEditor: React.FC<AutoEditorProps> = ({
         exportedAt: new Date().toISOString(),
         version: result.version,
         mode: result.mode,
-        factCheckId: factCheckReport.metadata?.processing_time_ms || Date.now()
+        factCheckId: factCheckReport.id
       },
       original: {
         text: result.originalText,

--- a/src/services/geminiService.ts
+++ b/src/services/geminiService.ts
@@ -8,6 +8,7 @@ import { enhancedFactCheck } from './textAnalysisService';
 import { RealTimeFactDBService } from './realTimeFactDB';
 import { FactDatabase, FactVerdict } from "../types/factDatabase";
 import { parseAIJsonResponse } from '../utils/jsonParser';
+import { generateSHA256 } from '../utils/hashUtils';
 
 // Helper function to extract text from different SDK response structures
 const extractTextFromGeminiResponse = (result: any): string => {
@@ -640,7 +641,7 @@ export async function runFactCheckOrchestrator(
   const cachedFact = await factDB.getFact(text);
   if (cachedFact && isFactFresh(cachedFact)) {
     console.log('✅ Using cached fact from database');
-    return convertFactToReport(cachedFact, text);
+    return await convertFactToReport(cachedFact, text);
   }
 
   // Proceed with original analysis if no cached result
@@ -662,8 +663,10 @@ function isFactFresh(fact: FactDatabase): boolean {
   return daysSinceVerification < 7; // Consider facts fresh for 7 days
 }
 
-function convertFactToReport(fact: FactDatabase, originalText: string): FactCheckReport {
+async function convertFactToReport(fact: FactDatabase, originalText: string): Promise<FactCheckReport> {
+    const factCheckId = await generateSHA256(`cached-database::${originalText.trim().toLowerCase()}`);
   return {
+    id: factCheckId,
     originalText,
     final_verdict: mapVerdictToString(fact.verdict),
     final_score: Math.round(fact.confidence * 100),
@@ -723,7 +726,8 @@ async function originalFactCheckOrchestrator(
     method: 'gemini-only' | 'google-ai' | 'hybrid' | 'citation-augmented',
     context?: string
 ): Promise<FactCheckReport> {
-    const cacheKey = `${method}::${claimText.trim().toLowerCase()}`;
+    const factCheckId = await generateSHA256(`${method}::${claimText.trim().toLowerCase()}`);
+    const cacheKey = factCheckId;
     const cachedReport = factCheckCache.get(cacheKey);
     if (cachedReport) {
         console.log(`[Cache] Hit for key: ${cacheKey}`);
@@ -760,6 +764,7 @@ async function originalFactCheckOrchestrator(
                 throw new Error(`Unsupported analysis method: ${method}`);
         }
 
+        report.id = factCheckId;
         report.metadata.processing_time_ms = Date.now() - startTime;
         report.originalText = claimText;
         

--- a/src/types/factCheck.ts
+++ b/src/types/factCheck.ts
@@ -61,6 +61,7 @@ export interface FactCheckMetadata {
 }
 
 export interface FactCheckReport {
+    id: string;
     originalText: string;
     final_verdict: string;
     final_score: number; // 0-100

--- a/src/utils/hashUtils.ts
+++ b/src/utils/hashUtils.ts
@@ -1,0 +1,7 @@
+export async function generateSHA256(input: string): Promise<string> {
+    const textAsBuffer = new TextEncoder().encode(input);
+    const hashBuffer = await crypto.subtle.digest('SHA-256', textAsBuffer);
+    const hashArray = Array.from(new Uint8Array(hashBuffer));
+    const hashHex = hashArray.map(b => b.toString(16).padStart(2, '0')).join('');
+    return hashHex;
+}


### PR DESCRIPTION
This commit resolves a 500 Internal Server Error that occurred when saving auto-editor results. The error was caused by an invalid `factCheckId` being sent to the server, which prevented the editor from accessing the fact-checked data.

The key changes are:
- A new SHA-256 hashing utility (`src/utils/hashUtils.ts`) is introduced to generate a unique and deterministic ID for each fact-check report.
- The fact-checking service (`src/services/geminiService.ts`) now uses this hash as the `factCheckId` for both new and cached reports.
- The `FactCheckReport` interface (`src/types/factCheck.ts`) is updated to include the new `id` field.
- The `AutoEditor` component (`src/components/AutoEditor.tsx`) is updated to correctly use the `factCheckReport.id` in all API calls, ensuring a valid ID is always sent to the server.

This ensures that the `factCheckId` is always a valid filename, resolving the blob storage error and allowing the auto-content editor to function correctly.