### PR TITLE
feat: Add option to select Gemini model

### DIFF
--- a/src/components/SettingsModal.tsx
+++ b/src/components/SettingsModal.tsx
@@ -8,12 +8,13 @@ interface SettingsModalProps {
 }
 
 const API_KEY_FIELDS = [
-    { id: 'gemini', label: 'Gemini API Key', group: 'Google APIs', url: 'https://aistudio.google.com/' },
-    { id: 'factCheck', label: 'Google Fact Check Tools API Key', group: 'Google APIs', url: 'https://developers.google.com/custom-search/v1/overview' },
-    { id: 'search', label: 'Google Search API Key', group: 'Google APIs', url: 'https://developers.google.com/custom-search/v1/overview' },
-    { id: 'searchId', label: 'Google Search ID', group: 'Google APIs', url: 'https://developers.google.com/custom-search/v1/overview' },
-    { id: 'newsdata', label: 'newsdata.io API Key', group: 'Third-Party APIs', url: 'https://newsdata.io/free-news-api' },
-    { id: 'serp', label: 'SERP API Key', group: 'Third-Party APIs', url: 'https://serphouse.com/' },
+    { id: 'gemini', label: 'Gemini API Key', group: 'Google APIs', url: 'https://aistudio.google.com/', type: 'password' },
+    { id: 'geminiModel', label: 'Gemini Model', group: 'Google APIs', type: 'select', options: ['gemini-1.5-flash-latest', 'gemini-1.5-pro-latest', 'gemini-pro'] },
+    { id: 'factCheck', label: 'Google Fact Check Tools API Key', group: 'Google APIs', url: 'https://developers.google.com/custom-search/v1/overview', type: 'password' },
+    { id: 'search', label: 'Google Search API Key', group: 'Google APIs', url: 'https://developers.google.com/custom-search/v1/overview', type: 'password' },
+    { id: 'searchId', label: 'Google Search ID', group: 'Google APIs', url: 'https://developers.google.com/custom-search/v1/overview', type: 'password' },
+    { id: 'newsdata', label: 'newsdata.io API Key', group: 'Third-Party APIs', url: 'https://newsdata.io/free-news-api', type: 'password' },
+    { id: 'serp', label: 'SERP API Key', group: 'Third-Party APIs', url: 'https://serphouse.com/', type: 'password' },
 ];
 
 const SettingsModal: React.FC<SettingsModalProps> = ({ isOpen, onClose }) => {
@@ -69,17 +70,32 @@ const SettingsModal: React.FC<SettingsModalProps> = ({ isOpen, onClose }) => {
                                         <label htmlFor={field.id} className="block text-sm font-medium text-slate-300 mb-1">
                                             {field.label}
                                         </label>
-                                        <input
-                                            type="password"
-                                            id={field.id}
-                                            value={keys[field.id] || ''}
-                                            onChange={(e) => handleInputChange(field.id, e.target.value)}
-                                            placeholder={`Enter your ${field.label}`}
-                                            className="w-full p-3 bg-slate-900/70 border border-slate-700 rounded-lg focus:ring-2 focus:ring-indigo-500 focus:border-indigo-500 transition-colors text-slate-200 placeholder-slate-400"
-                                        />
-                                        <p className="mt-2 text-xs text-slate-400">
-                                            Get your free API key from <a href={field.url} target="_blank" rel="noopener noreferrer" className="text-indigo-400 hover:underline">{field.url}</a>
-                                        </p>
+                                        {field.type === 'select' ? (
+                                            <select
+                                                id={field.id}
+                                                value={keys[field.id] || ''}
+                                                onChange={(e) => handleInputChange(field.id, e.target.value)}
+                                                className="w-full p-3 bg-slate-900/70 border border-slate-700 rounded-lg focus:ring-2 focus:ring-indigo-500 focus:border-indigo-500 transition-colors text-slate-200"
+                                            >
+                                                {field.options?.map(option => (
+                                                    <option key={option} value={option}>{option}</option>
+                                                ))}
+                                            </select>
+                                        ) : (
+                                            <input
+                                                type="password"
+                                                id={field.id}
+                                                value={keys[field.id] || ''}
+                                                onChange={(e) => handleInputChange(field.id, e.target.value)}
+                                                placeholder={`Enter your ${field.label}`}
+                                                className="w-full p-3 bg-slate-900/70 border border-slate-700 rounded-lg focus:ring-2 focus:ring-indigo-500 focus:border-indigo-500 transition-colors text-slate-200 placeholder-slate-400"
+                                            />
+                                        )}
+                                        {field.url && (
+                                            <p className="mt-2 text-xs text-slate-400">
+                                                Get your free API key from <a href={field.url} target="_blank" rel="noopener noreferrer" className="text-indigo-400 hover:underline">{field.url}</a>
+                                            </p>
+                                        )}
                                     </div>
                                 ))}
                             </div>

--- a/src/services/apiKeyService.ts
+++ b/src/services/apiKeyService.ts
@@ -1,5 +1,6 @@
 const API_KEYS_CONFIG = {
     gemini: 'gemini_api_key',
+    geminiModel: 'gemini_model', // Added for model selection
     factCheck: 'fact_check_api_key',
     search: 'search_api_key',
     searchId: 'search_id',
@@ -26,6 +27,11 @@ export const getGeminiApiKey = (): string => {
         return envApiKey;
     }
     return getKeyFromStorage('gemini', 'Gemini API key not found. Please set it in the .env file or in the Settings panel.');
+};
+
+export const getGeminiModel = (): string => {
+    const storedModel = localStorage.getItem(API_KEYS_CONFIG.geminiModel);
+    return storedModel || 'gemini-1.5-flash-latest'; // Default model
 };
 
 export const getFactCheckApiKey = (): string =>

--- a/src/services/geminiService.ts
+++ b/src/services/geminiService.ts
@@ -1,6 +1,6 @@
 import { GoogleGenAI, Type } from "@google/genai";
 import { FactCheckReport, ClaimNormalization, PreliminaryAnalysis } from '@/types/factCheck';
-import { getGeminiApiKey, getNewsDataApiKey } from './apiKeyService';
+import { getGeminiApiKey, getNewsDataApiKey, getGeminiModel } from './apiKeyService';
 import { NewsArticle, GoogleSearchResult } from "../types";
 import { factCheckCache } from './caching';
 import { search } from './webSearch';
@@ -311,7 +311,7 @@ Respond with exactly this JSON structure:
 }`;
 
         const result = await ai.models.generateContent({
-            model: "gemini-2.5-flash",
+            model: getGeminiModel(),
             contents: simplePrompt,
             config: {
                 temperature: 0.1,
@@ -379,7 +379,7 @@ Provide a JSON response with:
 Make sure your response is valid JSON.`;
 
         const result = await ai.models.generateContent({
-            model: "gemini-2.5-flash",
+            model: getGeminiModel(),
             contents: prompt,
             config: {
                 temperature: 0.2,
@@ -491,7 +491,7 @@ const runGoogleSearchAndAiCheck = async (normalizedClaim: ClaimNormalization, co
         ${FACT_CHECK_REPORT_TYPE_DEFINITION}
     `;
     const result = await ai.models.generateContent({
-        model: "gemini-2.5-flash",
+        model: getGeminiModel(),
         contents: prompt,
         config: {
             tools: [{ googleSearch: {} }],
@@ -518,7 +518,7 @@ const runHybridCheck = async (normalizedClaim: ClaimNormalization, context?: str
         ${FACT_CHECK_REPORT_TYPE_DEFINITION}
     `;
     const result = await ai.models.generateContent({
-        model: "gemini-2.5-flash",
+        model: getGeminiModel(),
         contents: prompt,
         config: {
             tools: [{ googleSearch: {} }],
@@ -555,7 +555,7 @@ const runCitationAugmentedCheck = async (normalizedClaim: ClaimNormalization, co
     `;
 
     const result = await ai.models.generateContent({
-        model: "gemini-2.5-flash",
+        model: getGeminiModel(),
         contents: preliminaryAnalysisPrompt,
         config: {
             responseMimeType: "application/json",
@@ -614,7 +614,7 @@ const runCitationAugmentedCheck = async (normalizedClaim: ClaimNormalization, co
     `;
 
     const finalResult = await ai.models.generateContent({
-        model: "gemini-2.5-flash",
+        model: getGeminiModel(),
         contents: finalAnalysisPrompt,
         config: {
             responseMimeType: "application/json",

--- a/src/services/intelligentCorrector.ts
+++ b/src/services/intelligentCorrector.ts
@@ -1,6 +1,6 @@
 import { SmartCorrection, DetectedIssue, CorrectionAnalysis } from '../types/corrections';
 import { AdvancedEvidence } from '../types/enhancedFactCheck';
-import { getGeminiApiKey } from './apiKeyService';
+import { getGeminiApiKey, getGeminiModel } from './apiKeyService';
 import { GoogleGenAI } from "@google/genai";
 import { parseAIJsonResponse } from '../utils/jsonParser';
 
@@ -53,7 +53,7 @@ export class IntelligentCorrector {
     try {
       // Reverting to the user's original call structure
       const result = await this.ai.models.generateContent({
-        model: "gemini-2.5-flash",
+        model: getGeminiModel(),
         contents: prompt,
       });
       // Assuming the user's response structure is correct for this SDK version
@@ -132,7 +132,7 @@ export class IntelligentCorrector {
     try {
       // Reverting to the user's original call structure
       const result = await this.ai.models.generateContent({
-        model: "gemini-2.5-flash",
+        model: getGeminiModel(),
         contents: prompt,
       });
       // Assuming the user's response structure is correct for this SDK version


### PR DESCRIPTION
This commit introduces a new feature that allows users to select the Gemini model they want to use for auto-correction and other AI-powered features. This addresses an issue where a hardcoded model name was causing errors due to it being unavailable or incorrect for the user's API key.

- Adds a dropdown menu in the Settings modal to select from a list of available Gemini models.
- The selected model is saved to and retrieved from local storage.
- All services making calls to the Gemini API now use the user-selected model, with a sensible default.
- Replaces all hardcoded instances of Gemini model names with a dynamic call to retrieve the user's selection.