### PR TITLE
feat: Dynamically fetch and select Gemini models

### DIFF
--- a/src/services/apiKeyService.ts
+++ b/src/services/apiKeyService.ts
@@ -31,7 +31,7 @@ export const getGeminiApiKey = (): string => {
 
 export const getGeminiModel = (): string => {
     const storedModel = localStorage.getItem(API_KEYS_CONFIG.geminiModel);
-    return storedModel || 'gemini-1.5-flash-latest'; // Default model
+    return storedModel || 'gemini-pro'; // Default model updated to a more standard one
 };
 
 export const getFactCheckApiKey = (): string =>


### PR DESCRIPTION
This commit refactors the Gemini model selection feature to be fully dynamic, resolving issues where hardcoded model names were causing 'model not found' errors.

- Implements a `listGeminiModels` function in `geminiService.ts` that makes a REST API call to fetch a list of all models available to the user's API key.
- The returned list is filtered to only include models that support the `generateContent` method.
- The Settings modal is updated to use this function, populating the model selection dropdown with the dynamically fetched list.
- Implements robust error handling: if the model list cannot be fetched, the dropdown is populated with an improved hardcoded fallback list, and a warning is displayed to the user.
- The default model in `apiKeyService.ts` is updated to `gemini-pro`, a more common and reliable default.
- All services making calls to the Gemini API continue to use the user-selected model via the `getGeminiModel` function.