### PR TITLE
fix(build): Add missing 'date' property to TemporalValidation type

### DIFF
--- a/src/types/factCheck.ts
+++ b/src/types/factCheck.ts
@@ -121,6 +121,7 @@ export interface TemporalValidation {
   confidence: number;
   dateType: 'past' | 'present' | 'near_future' | 'far_future';
   reasoning: string;
+  date?: string;
 }
 
 export interface TemporalAnalysis {


### PR DESCRIPTION
Resolves a TypeScript build error (TS2339) where the 'date' property was accessed on an object of type 'TemporalValidation' but was not defined in the interface.

The `enhancedFactCheckService` uses this property for filtering temporal validations. This change adds the optional 'date' property to the `TemporalValidation` interface in `src/types/factCheck.ts` to align the type definition with its usage.