### PR TITLE
Refactor: Move SERP and NewsData API calls to server-side

### DIFF
--- a/api/newsdata-search.ts
+++ b/api/newsdata-search.ts
@@ -1,0 +1,50 @@
+import type { VercelRequest, VercelResponse } from '@vercel/node';
+
+export default async function handler(req: VercelRequest, res: VercelResponse) {
+  res.setHeader('Access-Control-Allow-Origin', '*');
+  res.setHeader('Access-Control-Allow-Methods', 'GET, POST, OPTIONS');
+  res.setHeader('Access-Control-Allow-Headers', 'Content-Type');
+
+  if (req.method === 'OPTIONS') {
+    return res.status(200).end();
+  }
+
+  if (req.method !== 'POST') {
+    return res.status(405).json({ error: 'Method not allowed' });
+  }
+
+  const { query, fromDate, toDate, maxResults = 20 } = req.body;
+  const NEWSDATA_API_KEY = process.env.NEWSDATA_API_KEY;
+
+  if (!NEWSDATA_API_KEY) {
+    return res.status(500).json({ error: 'NewsData API key not configured' });
+  }
+
+  try {
+    const params = new URLSearchParams({
+      apikey: NEWSDATA_API_KEY,
+      q: query,
+      language: 'en',
+      country: 'us',
+      size: Math.min(maxResults, 50).toString()
+    });
+
+    if (fromDate) params.append('from_date', fromDate);
+    if (toDate) params.append('to_date', toDate);
+
+    const response = await fetch(`https://newsdata.io/api/1/news?${params}`);
+
+    if (!response.ok) {
+      throw new Error(`NewsData API error: ${response.status}`);
+    }
+
+    const data = await response.json();
+    return res.status(200).json(data);
+  } catch (error) {
+    console.error('NewsData API error:', error);
+    return res.status(500).json({
+      error: 'Failed to fetch news data',
+      details: error instanceof Error ? error.message : 'Unknown error'
+    });
+  }
+}

--- a/api/serp-search.ts
+++ b/api/serp-search.ts
@@ -1,0 +1,53 @@
+import type { VercelRequest, VercelResponse } from '@vercel/node';
+
+export default async function handler(req: VercelRequest, res: VercelResponse) {
+  // Enable CORS
+  res.setHeader('Access-Control-Allow-Origin', '*');
+  res.setHeader('Access-Control-Allow-Methods', 'GET, POST, OPTIONS');
+  res.setHeader('Access-Control-Allow-Headers', 'Content-Type');
+
+  if (req.method === 'OPTIONS') {
+    return res.status(200).end();
+  }
+
+  if (req.method !== 'POST') {
+    return res.status(405).json({ error: 'Method not allowed' });
+  }
+
+  const { query, num = 10 } = req.body;
+  const SERP_API_KEY = process.env.SERP_API_KEY;
+
+  if (!SERP_API_KEY) {
+    return res.status(500).json({ error: 'SERP API key not configured' });
+  }
+
+  try {
+    const params = new URLSearchParams({
+      api_key: SERP_API_KEY,
+      q: query,
+      num: num.toString(),
+      engine: 'google',
+      gl: 'us',
+      hl: 'en'
+    });
+
+    const response = await fetch(`https://serpapi.com/search.json?${params}`, {
+      headers: {
+        'Accept': 'application/json'
+      }
+    });
+
+    if (!response.ok) {
+      throw new Error(`SERP API error: ${response.status}`);
+    }
+
+    const data = await response.json();
+    return res.status(200).json(data);
+  } catch (error) {
+    console.error('SERP API error:', error);
+    return res.status(500).json({
+      error: 'Failed to fetch search results',
+      details: error instanceof Error ? error.message : 'Unknown error'
+    });
+  }
+}

--- a/src/services/queryExtractor.ts
+++ b/src/services/queryExtractor.ts
@@ -1,0 +1,151 @@
+import { GoogleGenAI, Type } from "@google/genai";
+import { getGeminiApiKey, getGeminiModel } from './apiKeyService';
+import { parseAIJsonResponse } from '../utils/jsonParser';
+
+interface ExtractedQueries {
+  primaryQuery: string;
+  subQueries: string[];
+  keywords: string[];
+  entities: Array<{
+    name: string;
+    type: 'person' | 'organization' | 'location' | 'event' | 'date' | 'concept';
+  }>;
+  searchPriority: 'high' | 'medium' | 'low';
+}
+
+const queryExtractionSchema = {
+  type: Type.OBJECT,
+  properties: {
+    primaryQuery: {
+      type: Type.STRING,
+      description: "Main search query optimized for fact-checking"
+    },
+    subQueries: {
+      type: Type.ARRAY,
+      items: { type: Type.STRING },
+      description: "Additional targeted queries for specific claims"
+    },
+    keywords: {
+      type: Type.ARRAY,
+      items: { type: Type.STRING },
+      description: "Key searchable terms"
+    },
+    entities: {
+      type: Type.ARRAY,
+      items: {
+        type: Type.OBJECT,
+        properties: {
+          name: { type: Type.STRING },
+          type: {
+            type: Type.STRING,
+            enum: ['person', 'organization', 'location', 'event', 'date', 'concept']
+          }
+        },
+        required: ['name', 'type']
+      }
+    },
+    searchPriority: {
+      type: Type.STRING,
+      enum: ['high', 'medium', 'low'],
+      description: "Priority level for search execution"
+    }
+  },
+  required: ['primaryQuery', 'subQueries', 'keywords', 'entities', 'searchPriority']
+};
+
+export class QueryExtractorService {
+  private static instance: QueryExtractorService;
+  private ai: GoogleGenAI;
+
+  private constructor() {
+    this.ai = new GoogleGenAI({ apiKey: getGeminiApiKey() });
+  }
+
+  static getInstance(): QueryExtractorService {
+    if (!QueryExtractorService.instance) {
+      QueryExtractorService.instance = new QueryExtractorService();
+    }
+    return QueryExtractorService.instance;
+  }
+
+  async extractSearchQueries(text: string): Promise<ExtractedQueries> {
+    try {
+      const prompt = `You are a search query optimization expert for fact-checking.
+
+Analyze this text and extract optimal search queries:
+"${text}"
+
+Generate:
+1. **Primary Query**: The most important search query to verify the main claim (20-60 characters, focused)
+2. **Sub-Queries**: 2-4 additional queries for specific sub-claims or details
+3. **Keywords**: 5-10 key searchable terms
+4. **Entities**: Identify people, organizations, locations, events, dates, concepts
+5. **Search Priority**: Rate the urgency (high for breaking news, low for historical facts)
+
+IMPORTANT:
+- Queries should be concise and searchable (not full sentences)
+- Focus on verifiable facts, not opinions
+- Include specific names, dates, locations when present
+- Prioritize queries that will find authoritative sources
+
+Examples:
+Text: "Elon Musk bought Twitter for $44 billion in October 2022"
+Primary: "Elon Musk Twitter acquisition 2022 price"
+Sub-Queries: ["Twitter deal $44 billion", "Elon Musk Twitter October 2022"]
+Keywords: ["Elon Musk", "Twitter", "acquisition", "$44 billion", "October 2022"]`;
+
+      const result = await this.ai.models.generateContent({
+        model: getGeminiModel(),
+        contents: prompt,
+        config: {
+          responseMimeType: "application/json",
+          responseSchema: queryExtractionSchema,
+          temperature: 0.3,
+          maxOutputTokens: 1500
+        }
+      });
+
+      const extracted = parseAIJsonResponse(result.text) as ExtractedQueries;
+
+      console.log('✅ Extracted Search Queries:', {
+        primary: extracted.primaryQuery,
+        subCount: extracted.subQueries.length,
+        keywords: extracted.keywords
+      });
+
+      return extracted;
+
+    } catch (error) {
+      console.error('Query extraction failed:', error);
+
+      // Fallback: basic keyword extraction
+      const words = text.toLowerCase()
+        .replace(/[^\w\s]/g, ' ')
+        .split(/\s+/)
+        .filter(word => word.length > 3)
+        .filter(word => !['that', 'this', 'with', 'from', 'have', 'been', 'were'].includes(word));
+
+      const uniqueWords = [...new Set(words)].slice(0, 5);
+
+      return {
+        primaryQuery: uniqueWords.join(' '),
+        subQueries: [],
+        keywords: uniqueWords,
+        entities: [],
+        searchPriority: 'medium'
+      };
+    }
+  }
+
+  async extractTemporalQuery(text: string, date: string): Promise<string> {
+    // For temporal verification, create date-specific queries
+    const dateObj = new Date(date);
+    const formattedDate = dateObj.toLocaleDateString('en-US', {
+      year: 'numeric',
+      month: 'long'
+    });
+
+    const queries = await this.extractSearchQueries(text);
+    return `${queries.primaryQuery} ${formattedDate}`;
+  }
+}


### PR DESCRIPTION
This commit refactors the application to move the SERP API and NewsData API calls from the client-side to new server-side Vercel serverless functions.

Key changes:
- Created `/api/serp-search.ts` to handle SERP API requests.
- Created `/api/newsdata-search.ts` to handle NewsData API requests.
- Modified `serpApiService.ts` to call the new `/api/serp-search` endpoint.
- Modified `newsDataService.ts` to call the new `/api/newsdata-search` endpoint.
- Removed client-side handling of `SERP_API_KEY` and `NEWSDATA_API_KEY`.

This resolves the critical security issue of exposing API keys on the client and fixes the associated CORS errors.