### PR TITLE
Fix: Handle missing SERP API key gracefully

### DIFF
--- a/api/serp-search.ts
+++ b/api/serp-search.ts
@@ -18,7 +18,20 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
   const SERP_API_KEY = process.env.SERP_API_KEY;
 
   if (!SERP_API_KEY) {
-    return res.status(500).json({ error: 'SERP API key not configured' });
+    console.warn('SERP_API_KEY not found. Returning empty search results.');
+    return res.status(200).json({
+      results: [],
+      aiOverview: null,
+      totalResults: 0,
+      error: 'SERP API key not configured.',
+      queries: {
+        primaryQuery: query,
+        subQueries: [],
+        keywords: [],
+        entities: [],
+        searchPriority: 'low'
+      }
+    });
   }
 
   try {


### PR DESCRIPTION
Modified `api/serp-search.ts` to return a 200 OK response with an empty result set and an error message when the `SERP_API_KEY` environment variable is not configured.

This change prevents the server from throwing a 500 error, which was causing a console error in the frontend. The new behavior allows the client-side application to handle the missing API key configuration as a non-critical issue, improving the overall robustness of the fact-checking service.