### PR TITLE
This commit resolves a frontend-backend data contract mismatch where …

### DIFF
--- a/api/newsdata-search.ts
+++ b/api/newsdata-search.ts
@@ -14,11 +14,11 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
 
     // 2. Log the incoming request body
     console.log(`[newsdata-search] Received body:`, req.body);
-    const { q, lang, country } = req.body;
+    const { query, lang, country } = req.body;
 
-    if (!q) {
-      console.error('[newsdata-search] Error: Missing "q" parameter in the request body.');
-      return res.status(400).json({ error: 'Bad Request: Missing required query parameter "q".' });
+    if (!query) {
+      console.error('[newsdata-search] Error: Missing "query" parameter in the request body.');
+      return res.status(400).json({ error: 'Bad Request: Missing required query parameter "query".' });
     }
 
     // 3. Securely check and log the environment variable
@@ -33,7 +33,7 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
 
     // 4. Construct and log the URL before fetching
     const apiUrl = `https://newsdata.io/api/1/news?apikey=${apiKey}&q=${encodeURIComponent(
-      q as string
+      query as string
     )}&language=${lang || 'en'}&country=${country || 'us'}`;
     // Log the URL with the API key redacted for security
     console.log(`[newsdata-search] Fetching URL: ${apiUrl.replace(apiKey, 'REDACTED')}`);

--- a/api/serp-search.ts
+++ b/api/serp-search.ts
@@ -25,11 +25,11 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
 
     // 2. Log the incoming request body
     console.log(`[serp-search] Received body:`, req.body);
-    const { q, engine } = req.body;
+    const { query, engine } = req.body;
 
-    if (!q) {
-      console.error('[serp-search] Error: Missing "q" parameter in the request body.');
-      return res.status(400).json({ error: 'Bad Request: Missing required query parameter "q".' });
+    if (!query) {
+      console.error('[serp-search] Error: Missing "query" parameter in the request body.');
+      return res.status(400).json({ error: 'Bad Request: Missing required query parameter "query".' });
     }
 
     // 3. Securely check and log the environment variable
@@ -46,7 +46,7 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
     const searchParams = new URLSearchParams({
         ...req.body,
         api_key: apiKey,
-        q: q as string,
+        q: query as string,
         engine: (engine as string) || 'google',
       });
 


### PR DESCRIPTION
…the frontend was sending a `query` parameter, but the backend was expecting `q`.

- Modified `api/serp-search.ts` to accept the `query` parameter from the request body.
- Modified `api/newsdata-search.ts` to accept the `query` parameter from the request body.
- The external API calls still correctly use the `q` parameter as required by the external services.

This change fixes the "400 Bad Request" errors and improves the clarity of the backend API.