### PR TITLE
fix(api): Truncate Webz.io query to prevent API errors

### DIFF
--- a/src/services/webzNewsService.ts
+++ b/src/services/webzNewsService.ts
@@ -10,10 +10,24 @@ export class WebzNewsService implements NewsSource {
 
   async searchNews(params: SearchParams): Promise<any> {
     const { query, fromDate } = params;
-    console.log(`[WebzNewsService] Searching for: "${query}" from date: ${fromDate}`);
+
+    const MAX_QUERY_LENGTH = 80; // Leave buffer under 100
+
+    // Truncate and clean the query
+    let cleanQuery = query
+      .trim()
+      .substring(0, MAX_QUERY_LENGTH);
+
+    // Ensure it doesn't cut off mid-word
+    const lastSpace = cleanQuery.lastIndexOf(' ');
+    if (lastSpace > 50) { // Keep at least 50 chars
+      cleanQuery = cleanQuery.substring(0, lastSpace);
+    }
+
+    console.log(`[WebzNewsService] Searching with truncated query (${cleanQuery.length} chars): "${cleanQuery}" from date: ${fromDate}`);
 
     const body = {
-      query,
+      query: cleanQuery,
       fromDate,
     };
 


### PR DESCRIPTION
This commit resolves the 500 errors from the Webz.io API by implementing query truncation on both the client and server.

- The backend API handler `api/webz-news-search.ts` now truncates queries to the strict 100-character limit imposed by Webz.io.
- The frontend service `src/services/webzNewsService.ts` proactively truncates queries to a safe 80-character limit before sending them to the backend, preventing oversized requests.