### PR TITLE
fix: Resolve Vercel build error and optimize fact-check API

### DIFF
--- a/api/fact-check.ts
+++ b/api/fact-check.ts
@@ -519,14 +519,22 @@ async function validateCitations(evidence: any[]) {
       let isValid = false;
 
       if (url) {
+        const controller = new AbortController();
+        const timeoutId = setTimeout(() => controller.abort(), 2000);
+
         try {
           // Simulate accessibility check
-          const response = await fetch(url, { method: 'HEAD', timeout: 2000 });
+          const response = await fetch(url, {
+            method: 'HEAD',
+            signal: controller.signal,
+          });
           accessibility = response.ok ? 'accessible' : 'inaccessible';
           isValid = true;
         } catch (error) {
           accessibility = 'inaccessible';
           isValid = false;
+        } finally {
+          clearTimeout(timeoutId);
         }
       }
 


### PR DESCRIPTION
This commit resolves a Vercel build error caused by a non-standard `timeout` property in a `fetch` call. It also includes performance optimizations for the tiered fact-checking API to prevent timeouts and consolidates serverless functions to comply with Vercel's free tier limits.

Key changes:
- Replaces the `timeout` property with a standard `AbortController` in the `validateCitations` function within `api/fact-check.ts`.
- Modifies the main handler in `/api/fact-check.ts` to execute data-gathering phases concurrently using `Promise.all`.
- Consolidates the logic from `/api/validate-citations.ts` into `/api/fact-check.ts` and removes the redundant file.
- Updates the `handleAutoCorrect` function in the frontend to call the `/api/auto-correct` endpoint, removing the final piece of mock data.