### PR TITLE
fix: Resolve Vercel build error and refactor API

### DIFF
--- a/src/api-lib/advanced-editor.ts
+++ b/src/api-lib/advanced-editor.ts
@@ -3,14 +3,16 @@ import type { VercelRequest, VercelResponse } from '@vercel/node';
 
 export default async function handler(req: VercelRequest, res: VercelResponse) {
   if (req.method !== 'POST') {
-    return res.status(405).json({ error: 'Method not allowed' });
+    res.status(405).json({ error: 'Method not allowed' });
+    return;
   }
 
   try {
     const { text, mode, prompt } = req.body;
 
     if (!text || !mode || !prompt) {
-      return res.status(400).json({ error: 'Missing required parameters' });
+      res.status(400).json({ error: 'Missing required parameters' });
+      return;
     }
 
     // Simple text processing based on mode
@@ -35,10 +37,12 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
       processingTime: Date.now(),
       confidence: 90
     });
+    return;
 
   } catch (error) {
     console.error('Advanced editor API error:', error);
     res.status(500).json({ error: 'Failed to process text' });
+    return;
   }
 }
 

--- a/src/api-lib/auto-correct.ts
+++ b/src/api-lib/auto-correct.ts
@@ -63,14 +63,16 @@ function buildAutoCorrectPrompt(text: string, factCheckResult: any, mode: string
 
 export default async function handler(req: VercelRequest, res: VercelResponse) {
   if (req.method !== 'POST') {
-    return res.status(405).json({ error: 'Method not allowed' });
+    res.status(405).json({ error: 'Method not allowed' });
+    return;
   }
 
   const startTime = Date.now();
   const { text, factCheckResult, mode }: AutoCorrectRequest = req.body;
 
   if (!text || !factCheckResult) {
-    return res.status(400).json({ error: 'Text and factCheckResult are required.' });
+    res.status(400).json({ error: 'Text and factCheckResult are required.' });
+    return;
   }
 
   try {
@@ -96,7 +98,6 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
     };
 
     res.status(200).json(editorResult);
-
   } catch (error: any) {
     console.error('❌ Auto-correction failed:', error);
     res.status(500).json({

--- a/src/api-lib/blob-analytics.ts
+++ b/src/api-lib/blob-analytics.ts
@@ -33,9 +33,11 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
       }
     };
 
-    return res.status(200).json(analyticsData);
+    res.status(200).json(analyticsData);
+    return;
   } catch (error) {
     console.error('Analytics error:', error);
-    return res.status(500).json({ error: 'Failed to load analytics' });
+    res.status(500).json({ error: 'Failed to load analytics' });
+    return;
   }
 }

--- a/src/api-lib/blob-delete-report.ts
+++ b/src/api-lib/blob-delete-report.ts
@@ -4,7 +4,8 @@ import type { VercelRequest, VercelResponse } from '@vercel/node';
 
 export default async function handler(req: VercelRequest, res: VercelResponse) {
   if (req.method !== 'POST') {
-    return res.status(405).json({ error: 'Method not allowed' });
+    res.status(405).json({ error: 'Method not allowed' });
+    return;
   }
 
   try {
@@ -13,9 +14,11 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
 
     await del(filename);
 
-    return res.status(200).json({ success: true });
+    res.status(200).json({ success: true });
+    return;
   } catch (error) {
     console.error('Failed to delete report from blob storage:', error);
-    return res.status(500).json({ error: 'Failed to delete report' });
+    res.status(500).json({ error: 'Failed to delete report' });
+    return;
   }
 }

--- a/src/api-lib/blob-export-bulk.ts
+++ b/src/api-lib/blob-export-bulk.ts
@@ -4,7 +4,8 @@ import type { VercelRequest, VercelResponse } from '@vercel/node';
 
 export default async function handler(req: VercelRequest, res: VercelResponse) {
   if (req.method !== 'POST') {
-    return res.status(405).json({ error: 'Method not allowed' });
+    res.status(405).json({ error: 'Method not allowed' });
+    return;
   }
 
   try {
@@ -36,15 +37,17 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
       contentType: 'application/json'
     });
 
-    return res.status(200).json({
+    res.status(200).json({
       success: true,
       exportId: bulkExportData.exportId,
       downloadUrl: blob.url,
       totalSessions: factCheckIds.length,
       format
     });
+    return;
   } catch (error) {
     console.error('Bulk export error:', error);
-    return res.status(500).json({ error: 'Failed to create bulk export' });
+    res.status(500).json({ error: 'Failed to create bulk export' });
+    return;
   }
 }

--- a/src/api-lib/blob-load-editor-history.ts
+++ b/src/api-lib/blob-load-editor-history.ts
@@ -6,7 +6,8 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
     const { factCheckId, mode } = req.query;
 
     if (!factCheckId) {
-      return res.status(400).json({ error: 'factCheckId is required' });
+      res.status(400).json({ error: 'factCheckId is required' });
+      return;
     }
 
     // In a real implementation, you would query your database
@@ -16,9 +17,11 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
       results: [] // This would be populated from actual blob storage
     };
 
-    return res.status(200).json(mockHistory);
+    res.status(200).json(mockHistory);
+    return;
   } catch (error) {
     console.error('Load history error:', error);
-    return res.status(500).json({ error: 'Failed to load editor history' });
+    res.status(500).json({ error: 'Failed to load editor history' });
+    return;
   }
 }

--- a/src/api-lib/blob-save-batch-results.ts
+++ b/src/api-lib/blob-save-batch-results.ts
@@ -4,7 +4,8 @@ import type { VercelRequest, VercelResponse } from '@vercel/node';
 
 export default async function handler(req: VercelRequest, res: VercelResponse) {
   if (req.method !== 'POST') {
-    return res.status(405).json({ error: 'Method not allowed' });
+    res.status(405).json({ error: 'Method not allowed' });
+    return;
   }
 
   try {
@@ -49,14 +50,16 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
       })
     );
 
-    return res.status(200).json({
+    res.status(200).json({
       success: true,
       batchUrl: batchBlob.url,
       urls: individualUrls,
       totalResults: results.length
     });
+    return;
   } catch (error) {
     console.error('Batch blob save error:', error);
-    return res.status(500).json({ error: 'Failed to save batch results' });
+    res.status(500).json({ error: 'Failed to save batch results' });
+    return;
   }
 }

--- a/src/api-lib/blob-save-fact-database.ts
+++ b/src/api-lib/blob-save-fact-database.ts
@@ -4,7 +4,8 @@ import type { VercelRequest, VercelResponse } from '@vercel/node';
 
 export default async function handler(req: VercelRequest, res: VercelResponse) {
   if (req.method !== 'POST') {
-    return res.status(405).json({ error: 'Method not allowed' });
+    res.status(405).json({ error: 'Method not allowed' });
+    return;
   }
 
   try {
@@ -28,11 +29,13 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
 
     console.log('Successfully saved fact database. Blob URL:', blob.url);
 
-    return res.status(200).json({ success: true, url: blob.url });
+    res.status(200).json({ success: true, url: blob.url });
+    return;
   } catch (error: any) {
     console.error('Failed to save fact database:', error);
-    return res.status(500).json(
+    res.status(500).json(
       { error: 'Failed to save fact database', details: error.message }
     );
+    return;
   }
 }

--- a/src/api-lib/blob-save-report.ts
+++ b/src/api-lib/blob-save-report.ts
@@ -4,7 +4,8 @@ import type { VercelRequest, VercelResponse } from '@vercel/node';
 
 export default async function handler(req: VercelRequest, res: VercelResponse) {
   if (req.method !== 'POST') {
-    return res.status(405).json({ error: 'Method not allowed' });
+    res.status(405).json({ error: 'Method not allowed' });
+    return;
   }
 
   try {
@@ -16,9 +17,11 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
       addRandomSuffix: false,
     });
 
-    return res.status(200).json({ success: true, url: blob.url });
+    res.status(200).json({ success: true, url: blob.url });
+    return;
   } catch (error) {
     console.error('Failed to save report to blob storage:', error);
-    return res.status(500).json({ error: 'Failed to save report' });
+    res.status(500).json({ error: 'Failed to save report' });
+    return;
   }
 }

--- a/src/api-lib/fact-check.ts
+++ b/src/api-lib/fact-check.ts
@@ -11,14 +11,16 @@ interface FactCheckRequest {
 
 export default async function handler(req: VercelRequest, res: VercelResponse) {
   if (req.method !== 'POST') {
-    return res.status(405).json({ error: 'Method not allowed' });
+    res.status(405).json({ error: 'Method not allowed' });
+    return;
   }
 
   const startTime = Date.now();
   const { text, publishingContext = 'journalism' }: FactCheckRequest = req.body;
 
   if (!text || text.trim().length === 0) {
-    return res.status(400).json({ error: 'Text is required for fact-checking' });
+    res.status(400).json({ error: 'Text is required for fact-checking' });
+    return;
   }
 
   console.log('🎯 Starting Optimized Tiered Fact-Check');
@@ -56,11 +58,12 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
     );
 
     console.log('✅ Tiered Fact-Check Complete:', finalReport.final_score);
-    return res.status(200).json(finalReport);
+    res.status(200).json(finalReport);
+    return;
 
   } catch (error: any) {
     console.error('❌ Fact-check failed:', error);
-    return res.status(500).json({
+    res.status(500).json({
       error: 'Fact-check failed',
       details: error.message,
       id: `error_${Date.now()}`,
@@ -70,6 +73,7 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
       evidence: [],
       processingTime: Date.now() - startTime
     });
+    return;
   }
 }
 

--- a/src/api-lib/generate-schema.ts
+++ b/src/api-lib/generate-schema.ts
@@ -30,18 +30,21 @@ export default function handler(req: VercelRequest, res: VercelResponse) {
   res.setHeader('Access-Control-Allow-Headers', 'Content-Type');
 
   if (req.method === 'OPTIONS') {
-    return res.status(200).end();
+    res.status(200).end();
+    return;
   }
 
   if (req.method !== 'POST') {
     res.setHeader('Allow', 'POST');
-    return res.status(405).end('Method Not Allowed');
+    res.status(405).end('Method Not Allowed');
+    return;
   }
 
   const { claim, score, verdict, evidence, publisherInfo } = req.body as SchemaRequestBody;
 
   if (!claim || score === undefined || !verdict || !publisherInfo) {
-    return res.status(400).json({ error: 'Missing required fields: claim, score, verdict, publisherInfo' });
+    res.status(400).json({ error: 'Missing required fields: claim, score, verdict, publisherInfo' });
+    return;
   }
 
   const { organizationName, organizationUrl, articleUrl, headline, authorName } = publisherInfo;

--- a/src/api-lib/serp-search.ts
+++ b/src/api-lib/serp-search.ts
@@ -7,17 +7,20 @@ const MAX_QUERY_LENGTH = 2048;
 
 export default async function handler(req: VercelRequest, res: VercelResponse) {
     if (req.method !== 'POST') {
-        return res.status(405).json({ message: 'Method Not Allowed' });
+        res.status(405).json({ message: 'Method Not Allowed' });
+        return;
     }
 
     let { query } = req.body;
     const apiKey = process.env.SERP_API_KEY;
 
     if (!apiKey) {
-        return res.status(500).json({ message: 'SERP API key not configured' });
+        res.status(500).json({ message: 'SERP API key not configured' });
+        return;
     }
     if (!query || typeof query !== 'string') {
-        return res.status(400).json({ message: 'Query is required and must be a string' });
+        res.status(400).json({ message: 'Query is required and must be a string' });
+        return;
     }
 
     // --- START OF FIX ---
@@ -40,12 +43,15 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
         const data = await response.json();
         if (!response.ok) {
             console.error('[serp-search] Serper API returned an error:', data);
-            return res.status(response.status).json(data);
+            res.status(response.status).json(data);
+            return;
         }
 
-        return res.status(200).json(data);
+        res.status(200).json(data);
+        return;
     } catch (error: any) {
         console.error('[serp-search] An unexpected error occurred:', error);
-        return res.status(500).json({ message: 'An internal error occurred' });
+        res.status(500).json({ message: 'An internal error occurred' });
+        return;
     }
 }

--- a/src/api-lib/webz-news-search.ts
+++ b/src/api-lib/webz-news-search.ts
@@ -10,7 +10,8 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
 
     if (!query) {
       console.error('[webz-news-search] Error: Missing "query" parameter in the request body.');
-      return res.status(400).json({ error: 'Bad Request: Missing required "query" parameter.' });
+      res.status(400).json({ error: 'Bad Request: Missing required "query" parameter.' });
+      return;
     }
 
     // CRITICAL: Truncate query to Webz.io's 100 character limit
@@ -23,7 +24,8 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
     const apiKey = process.env.WEBZ_API_KEY;
     if (!apiKey) {
       console.error('[webz-news-search] FATAL: WEBZ_API_KEY environment variable not found!');
-      return res.status(500).json({ error: 'Server Configuration Error: Webz.io API key not configured.' });
+      res.status(500).json({ error: 'Server Configuration Error: Webz.io API key not configured.' });
+      return;
     }
 
     console.log(`[webz-news-search] API Key loaded successfully.`);
@@ -55,16 +57,18 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
       const errorText = await response.text();
       console.error(`[webz-news-search] Webz.io API Error: ${response.status}`, errorText);
 
-      return res.status(500).json({
+      res.status(500).json({
         message: 'Failed to fetch from the news API.',
         details: errorText,
         hint: 'Query may exceed Webz.io API limits (100 characters max)'
       });
+      return;
     }
 
     const data = await response.json();
     console.log('[webz-news-search] Successfully fetched data. Sending 200 OK response.');
     res.status(200).json(data);
+    return;
 
   } catch (error: any) {
     console.error('[webz-news-search] An unexpected error occurred in the handler:', error);
@@ -72,5 +76,6 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
       error: 'Internal Server Error',
       details: error.message || 'An unknown error occurred.',
     });
+    return;
   }
 }


### PR DESCRIPTION
This commit resolves a Vercel build error caused by exceeding the 12 serverless function limit on the Hobby plan. It also fixes a TypeScript build error and optimizes the application.

Key changes:
- All API logic has been moved from the `/api` directory to a new `/src/api-lib` directory.
- A single consolidated API endpoint has been created at `/api/index.ts`, which acts as a router to delegate requests to the appropriate handlers. This reduces the number of serverless functions to one.
- The frontend services in `TruScopeJournalismPlatform.tsx` have been updated to use the new single `/api` endpoint, passing an `action` parameter.
- `App.tsx` has been updated to use `React.lazy` and `Suspense` for code splitting to address a large chunk size warning.
- A TypeScript build error caused by a non-standard `timeout` property in a `fetch` call has been fixed by using a standard `AbortController`.
- All `return res.status().json()` calls in the API handlers have been corrected to `res.status().json(); return;` to conform to the `Promise<void>` return type.
- Missing context and component files (`SettingsContext`, `AppStateContext`, `DashboardSkeleton`, `tooltip`) have been created to resolve build-time import errors.